### PR TITLE
Apply global flag to wordDefinitionRegexp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const reporter = function (
 
   const handleText = (node, text, indexOffset) => {
     if (!text) return;
-    const wordDefinitionRegexp = new RegExp(optionWordDefinitionRegexp, 'g');
+    const wordDefinitionRegexp = new RegExp(optionWordDefinitionRegexp, "g");
 
     let noExclusionsOverlapWord;
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const reporter = function (
 
   const handleText = (node, text, indexOffset) => {
     if (!text) return;
-    const wordDefinitionRegexp = new RegExp(optionWordDefinitionRegexp);
+    const wordDefinitionRegexp = new RegExp(optionWordDefinitionRegexp, 'g');
 
     let noExclusionsOverlapWord;
 

--- a/test/word-definition.js
+++ b/test/word-definition.js
@@ -38,3 +38,39 @@ tester.run(
     ],
   }
 );
+
+tester.run(
+  "spelling with word definition from string-based configuration",
+  {
+    rules: [
+      {
+        ruleId: "spelling",
+        rule,
+        options: { wordDefinitionRegexp: "[\\w']+" },
+      },
+    ],
+  },
+  {
+    valid: [
+      `Fifty-six`,
+      `three-year-old children`,
+      `A triplet of three year-old children`,
+      `self-serving reasons`,
+      `president-elect`,
+      `ex-wife`,
+    ],
+    invalid: [
+      {
+        text: "It is colour.",
+        output: "It is color.",
+        errors: [
+          {
+            message: "colour -> color",
+            line: 1,
+            column: 7,
+          },
+        ],
+      },
+    ],
+  }
+);


### PR DESCRIPTION
Currently when configuring from `.textlintrc` there is no way to specify a wordDefinitionRegexp that will match globally. The [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp) constructor does not accept flags as part of a string based pattern.

Including the global flag seems to be a sensible default that works around this.