### PR TITLE
Ignore surrounding single quotation marks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ const reporter = function (
   {
     language = "en",
     skipPatterns = [],
-    wordDefinitionRegexp: optionWordDefinitionRegexp = /[\w']+/g,
+    wordDefinitionRegexp: optionWordDefinitionRegexp = /\b[\w']+\b/g,
     suggestCorrections = true,
   }
 ) {

--- a/test/basics.js
+++ b/test/basics.js
@@ -29,6 +29,7 @@ tester.run(
       "spelling is hard, we must meet our user's needs and/or requirements",
       `spelling is hard, we must meet our user's needs
 and/or requirements`,
+      "sometimes single 'quotes' are used too",
     ],
     invalid: [
       {


### PR DESCRIPTION
Minor tweak to the default word tokeniser to prevent surrounding single quotes from being captured as part of the words used in dictionary lookups.